### PR TITLE
qt viswidget: use glad to init

### DIFF
--- a/examples/qt/CMakeLists.txt
+++ b/examples/qt/CMakeLists.txt
@@ -29,7 +29,7 @@ include_directories(${qtmorph_SOURCE_DIR})
 include_directories(BEFORE ${PROJECT_SOURCE_DIR})
 
 # Ensure our programs will get the correct links
-set(MORPH_LIBS_GL OpenGL::GL glfw Freetype::Freetype)
+set(MORPH_LIBS_GL OpenGL::GL Freetype::Freetype)
 set(MORPH_LIBS_CORE ${HDF5_C_LIBRARIES})
 
 # Just about the simplest possible Qt morphologica program - draws the

--- a/examples/qt/fps/mainwindow.h
+++ b/examples/qt/fps/mainwindow.h
@@ -2,7 +2,6 @@
 #define MAINWINDOW_H
 
 #include <QMainWindow>
-#include <QOpenGLWidget>
 QT_BEGIN_NAMESPACE
 namespace Ui { class MainWindow; }
 QT_END_NAMESPACE
@@ -11,6 +10,8 @@ QT_END_NAMESPACE
 #include <sm/vec>
 #include <sm/vvec>
 #include <sm/hexgrid>
+
+class QOpenGLWidget;
 
 class MainWindow : public QMainWindow
 {

--- a/examples/qt/hexgrid/mainwindow.h
+++ b/examples/qt/hexgrid/mainwindow.h
@@ -2,7 +2,6 @@
 #define MAINWINDOW_H
 
 #include <QMainWindow>
-#include <QOpenGLWidget>
 QT_BEGIN_NAMESPACE
 namespace Ui { class MainWindow; }
 QT_END_NAMESPACE
@@ -11,6 +10,8 @@ QT_END_NAMESPACE
 #include <sm/vec>
 #include <sm/vvec>
 #include <sm/hexgrid>
+
+class QOpenGLWidget;
 
 class MainWindow : public QMainWindow
 {

--- a/mplot/VisualOwnableNoMX.h
+++ b/mplot/VisualOwnableNoMX.h
@@ -290,7 +290,6 @@ namespace mplot {
         }
 
     public:
-#ifdef GLAD_GL // Only define if GL was included with GLAD
         void init_glad (GLADloadfunc procaddressfn)
         {
             this->glfn_version = gladLoadGL (procaddressfn);
@@ -298,7 +297,6 @@ namespace mplot {
                 throw std::runtime_error ("Failed to initialize GLAD GL context");
             }
         }
-#endif
 
         //! Add a label _text to the scene at position _toffset. Font features are
         //! defined by the tfeatures. Return geometry of the text.

--- a/mplot/qt/viswidget.h
+++ b/mplot/qt/viswidget.h
@@ -3,16 +3,19 @@
 #include <iostream>
 #include <functional>
 
-#include <QtWidgets/QOpenGLWidget>
-#include <QOpenGLFunctions_4_1_Core> // problem is that this loads GL headers, so we don't load glad, further on
-#include <QSurfaceFormat>
-#include <QMouseEvent>
-#include <QWheelEvent>
+class QOpenGLWidget;
 
 // VisualOwnable is going to be owned by the QOpenGLWidget
 // Define mplot::win_t before #including mplot/VisualOwnableNoMX.h
 namespace mplot { using win_t = QOpenGLWidget; }
 #include <mplot/VisualOwnableNoMX.h>
+
+#include <QtWidgets/QOpenGLWidget>
+#include <QOpenGLContext>
+#include <QSurfaceFormat>
+#include <QMouseEvent>
+#include <QWheelEvent>
+
 // We need to be able to convert from Qt keycodes to mplot keycodes
 #include <mplot/qt/keycodes.h>
 
@@ -22,8 +25,16 @@ namespace mplot {
         // This must match the QOpenGLFunctions_4_1_Core class you derive from
         constexpr int gl_version = mplot::gl::version_4_1;
 
+        struct OpenGLProcAddressHelper {
+            inline static QOpenGLContext *ctx;
+
+            static QFunctionPointer getProcAddress(const char *name) {
+                return ctx->getProcAddress(name);
+            }
+        };
+
         // A mplot::VisualOwnable-based widget
-        struct viswidget : public QOpenGLWidget, protected QOpenGLFunctions_4_1_Core
+        struct viswidget : public QOpenGLWidget
         {
             // Unlike the GLFW or mplot-in-a-QWindow schemes, we hold the mplot::VisualOwnable
             // inside the widget.
@@ -59,7 +70,8 @@ namespace mplot {
             void initializeGL() override
             {
                 // Make sure we can call gl functions
-                initializeOpenGLFunctions();
+                OpenGLProcAddressHelper::ctx = context();
+                v.init_glad(OpenGLProcAddressHelper::getProcAddress);
                 // Switch on multisampling anti-aliasing (with the num samples set in constructor)
                 glEnable (GL_MULTISAMPLE);
                 // Initialise mplot::VisualOwnable


### PR DESCRIPTION
Fixes https://github.com/sebsjames/mathplot/issues/40

I found `viswidget_mx` uses glad to init, so it maybe ok to change the viswidget init behaviour?

The GL header inclusion order doesn't make the users happy😭, I think we should all use glad, and tell the users to include glad as early as possible(before QOpenGLWidget or glfw)