### PR TITLE
Correct rotation behaviour

### DIFF
--- a/mplot/VisualBase.h
+++ b/mplot/VisualBase.h
@@ -683,19 +683,19 @@ namespace mplot {
         void computeSceneview_about_scene_origin()
         {
             sm::mat44<float> sv_tr;
-            sm::mat44<float> sv_rot;
+            sm::mat44<float> sv_rot; // starts with no rotation
             if (this->ptype == perspective_type::orthographic || this->ptype == perspective_type::perspective) {
                 sv_tr.translate (this->scenetrans_delta);
                 // A rotation delta in world frame about the 'screen centre'
                 sv_rot.pretranslate (this->savedSceneview.translation());
-                sv_rot.rotate (this->rotation_delta);
+                sv_rot.rotate (this->rotation_delta); // apply rotation to sv_rot
                 sv_rot.pretranslate (-this->savedSceneview.translation());
             } else {
                 // Only rotate in cyl view
                 sv_rot.rotate (this->rotation_delta);
             }
 
-            this->sceneview = sv_tr * this->savedSceneview * sv_rot;
+            this->sceneview = sv_tr * this->savedSceneview * sv_rot; // replace sceneview with savedSceneView * sv_rot
             this->sceneview_tr = sv_tr * this->savedSceneview_tr;
         }
 
@@ -1168,20 +1168,18 @@ namespace mplot {
                 // Calculate new rotation axis as weighted sum
                 this->rotationAxis = (mouseMoveWorld * rotamount); // rotationAxis is in world frame
                 this->rotationAxis.renormalize();
-                std::cout << "rotationAxis = " << rotationAxis << std::endl;
+                std::cout << "\Mouse-commanded rotationAxis = " << rotationAxis << std::endl;
 
                 // NOW transform rotationAxis due to current orientation?
                 sm::quaternion<float> svrq = this->sceneview.rotation();
-                svrq.renormalize();
                 svrq.invert();
                 svrq.renormalize();
+                std::cout << " inverse scene rotation: " << svrq << std::endl;
+
+                // Change rotationAxis and thus rotation_delta
                 this->rotationAxis = svrq * this->rotationAxis;
                 this->rotationAxis.renormalize();
-                std::cout << "New rotationAxis = " << rotationAxis << std::endl;
-
-                // not this:
-                //this->rotationAxis = (this->sceneview * this->rotationAxis).less_one_dim();
-                //this->rotationAxis.renormalize();
+                std::cout << " New rotationAxis = " << rotationAxis << std::endl;
 
                 // rotation_delta is a rotation in the world frame of reference
                 this->rotation_delta.set_rotation (this->rotationAxis, -rotamount * sm::mathconst<float>::deg2rad);

--- a/mplot/VisualBase.h
+++ b/mplot/VisualBase.h
@@ -1168,6 +1168,20 @@ namespace mplot {
                 // Calculate new rotation axis as weighted sum
                 this->rotationAxis = (mouseMoveWorld * rotamount); // rotationAxis is in world frame
                 this->rotationAxis.renormalize();
+                std::cout << "rotationAxis = " << rotationAxis << std::endl;
+
+                // NOW transform rotationAxis due to current orientation?
+                sm::quaternion<float> svrq = this->sceneview.rotation();
+                svrq.renormalize();
+                svrq.invert();
+                svrq.renormalize();
+                this->rotationAxis = svrq * this->rotationAxis;
+                this->rotationAxis.renormalize();
+                std::cout << "New rotationAxis = " << rotationAxis << std::endl;
+
+                // not this:
+                //this->rotationAxis = (this->sceneview * this->rotationAxis).less_one_dim();
+                //this->rotationAxis.renormalize();
 
                 // rotation_delta is a rotation in the world frame of reference
                 this->rotation_delta.set_rotation (this->rotationAxis, -rotamount * sm::mathconst<float>::deg2rad);

--- a/mplot/VisualBase.h
+++ b/mplot/VisualBase.h
@@ -1159,11 +1159,10 @@ namespace mplot {
                     mouseMoveWorld[0] = -((v1[1] / v1[3]) - (v0[1] / v0[3]));
                 }
 
-                float rotamount = mouseMoveWorld.length() * 40.0f; // chosen in degrees
                 // Now transform the rotation axis due to the scene orientation (the saved one)
                 sm::vec<float> rotationAxis = this->savedSceneview.rotation().invert() * mouseMoveWorld;
                 // rotation_delta is the mouse-commanded rotation in the scene frame of reference
-                this->rotation_delta.set_rotation (rotationAxis, -rotamount * sm::mathconst<float>::deg2rad);
+                this->rotation_delta.set_rotation (rotationAxis, mouseMoveWorld.length() * -40.0f * sm::mathconst<float>::deg2rad);
 
                 needs_render = true;
 

--- a/mplot/VisualBase.h
+++ b/mplot/VisualBase.h
@@ -826,9 +826,6 @@ namespace mplot {
         //! Screen coordinates of the position of the last mouse press
         sm::vec<float,2> mousePressPosition = { 0.0f, 0.0f };
 
-        //! The current rotation axis. World frame.
-        sm::vec<float, 3> rotationAxis = { 0.0f, 0.0f, 0.0f };
-
         //! Add additional rotation to the scene
         sm::quaternion<float> rotation_delta;
 
@@ -1111,8 +1108,7 @@ namespace mplot {
         //! Rotate the scene about axis by angle (angle in radians)
         void rotate_scene (const sm::vec<float>& axis, const float angle)
         {
-            this->rotationAxis = axis;
-            sm::quaternion<float> rotnQuat (this->rotationAxis, -angle);
+            sm::quaternion<float> rotnQuat (axis, -angle);
             this->sceneview.prerotate (rotnQuat);
         }
 
@@ -1153,7 +1149,8 @@ namespace mplot {
                 sm::vec<float, 4> v1 = this->invproj * p1;
 
                 // This computes the difference between v0 and v1, the 2 mouse positions in the world
-                // space. Note the swap between x and y
+                // space. Note the swap between x and y.
+                // mouseMoveWorld is the rotation axis in the viewer's frame of reference
                 if (this->state.test (visual_state::rotateModMode)) {
                     // Sort of "rotate the page" mode.
                     mouseMoveWorld[2] = -((v1[1] / v1[3]) - (v0[1] / v0[3])) + ((v1[0] / v1[3]) - (v0[0] / v0[3]));
@@ -1162,29 +1159,11 @@ namespace mplot {
                     mouseMoveWorld[0] = -((v1[1] / v1[3]) - (v0[1] / v0[3]));
                 }
 
-                // Rotation axis is perpendicular to the mouse position difference vector BUT we
-                // have to project into the model frame to determine how to rotate the model!
                 float rotamount = mouseMoveWorld.length() * 40.0f; // chosen in degrees
-                // Calculate new rotation axis as weighted sum
-                //this->rotationAxis = (mouseMoveWorld/* * rotamount*/); // rotationAxis is in world frame
-                mouseMoveWorld.renormalize();
-                std::cout << "\nMouse-commanded rotationAxis = " << mouseMoveWorld << " (length "
-                          << mouseMoveWorld.length() << "), amount: " << -rotamount << " deg\n";
-
-                // NOW transform rotationAxis due to current orientation?
-                sm::quaternion<float> cur = this->sceneview.rotation();
-                std::cout << "         scene rotation: " << cur << std::endl;
-                sm::quaternion<float> curinv = cur.inverse(); // inverse or invert, same result
-                curinv.renormalize();
-                std::cout << " inverse scene rotation: " << curinv << std::endl;
-                // Change rotationAxis and thus rotation_delta
-                this->rotationAxis = curinv * mouseMoveWorld; // This operation?
-                this->rotationAxis.renormalize();
-                std::cout << " New rotationAxis = " << this->rotationAxis <<" (length "<< this->rotationAxis.length() << ")\n";
-                // rotation_delta is a rotation in the world frame of reference
-                std::cout << " Rotn amount = " <<  (-rotamount * sm::mathconst<float>::deg2rad) << " radians\n";
-                this->rotation_delta.set_rotation (this->rotationAxis, -rotamount * sm::mathconst<float>::deg2rad);
-                this->rotation_delta.renormalize();
+                // Now transform the rotation axis due to the scene orientation (the saved one)
+                sm::vec<float> rotationAxis = this->savedSceneview.rotation().invert() * mouseMoveWorld;
+                // rotation_delta is the mouse-commanded rotation in the scene frame of reference
+                this->rotation_delta.set_rotation (rotationAxis, -rotamount * sm::mathconst<float>::deg2rad);
 
                 needs_render = true;
 

--- a/mplot/VisualBase.h
+++ b/mplot/VisualBase.h
@@ -1166,23 +1166,25 @@ namespace mplot {
                 // have to project into the model frame to determine how to rotate the model!
                 float rotamount = mouseMoveWorld.length() * 40.0f; // chosen in degrees
                 // Calculate new rotation axis as weighted sum
-                this->rotationAxis = (mouseMoveWorld * rotamount); // rotationAxis is in world frame
-                this->rotationAxis.renormalize();
-                std::cout << "\Mouse-commanded rotationAxis = " << rotationAxis << std::endl;
+                //this->rotationAxis = (mouseMoveWorld/* * rotamount*/); // rotationAxis is in world frame
+                mouseMoveWorld.renormalize();
+                std::cout << "\nMouse-commanded rotationAxis = " << mouseMoveWorld << " (length "
+                          << mouseMoveWorld.length() << "), amount: " << -rotamount << " deg\n";
 
                 // NOW transform rotationAxis due to current orientation?
-                sm::quaternion<float> svrq = this->sceneview.rotation();
-                svrq.invert();
-                svrq.renormalize();
-                std::cout << " inverse scene rotation: " << svrq << std::endl;
-
+                sm::quaternion<float> cur = this->sceneview.rotation();
+                std::cout << "         scene rotation: " << cur << std::endl;
+                sm::quaternion<float> curinv = cur.inverse(); // inverse or invert, same result
+                curinv.renormalize();
+                std::cout << " inverse scene rotation: " << curinv << std::endl;
                 // Change rotationAxis and thus rotation_delta
-                this->rotationAxis = svrq * this->rotationAxis;
+                this->rotationAxis = curinv * mouseMoveWorld; // This operation?
                 this->rotationAxis.renormalize();
-                std::cout << " New rotationAxis = " << rotationAxis << std::endl;
-
+                std::cout << " New rotationAxis = " << this->rotationAxis <<" (length "<< this->rotationAxis.length() << ")\n";
                 // rotation_delta is a rotation in the world frame of reference
+                std::cout << " Rotn amount = " <<  (-rotamount * sm::mathconst<float>::deg2rad) << " radians\n";
                 this->rotation_delta.set_rotation (this->rotationAxis, -rotamount * sm::mathconst<float>::deg2rad);
+                this->rotation_delta.renormalize();
 
                 needs_render = true;
 

--- a/mplot/VisualBase.h
+++ b/mplot/VisualBase.h
@@ -683,19 +683,19 @@ namespace mplot {
         void computeSceneview_about_scene_origin()
         {
             sm::mat44<float> sv_tr;
-            sm::mat44<float> sv_rot; // starts with no rotation
+            sm::mat44<float> sv_rot;
             if (this->ptype == perspective_type::orthographic || this->ptype == perspective_type::perspective) {
                 sv_tr.translate (this->scenetrans_delta);
                 // A rotation delta in world frame about the 'screen centre'
                 sv_rot.pretranslate (this->savedSceneview.translation());
-                sv_rot.rotate (this->rotation_delta); // apply rotation to sv_rot
+                sv_rot.rotate (this->rotation_delta);
                 sv_rot.pretranslate (-this->savedSceneview.translation());
             } else {
                 // Only rotate in cyl view
                 sv_rot.rotate (this->rotation_delta);
             }
 
-            this->sceneview = sv_tr * this->savedSceneview * sv_rot; // replace sceneview with savedSceneView * sv_rot
+            this->sceneview = sv_tr * this->savedSceneview * sv_rot;
             this->sceneview_tr = sv_tr * this->savedSceneview_tr;
         }
 
@@ -1148,9 +1148,9 @@ namespace mplot {
                 sm::vec<float, 4> v0 = this->invproj * p0;
                 sm::vec<float, 4> v1 = this->invproj * p1;
 
-                // This computes the difference between v0 and v1, the 2 mouse positions in the world
-                // space. Note the swap between x and y.
-                // mouseMoveWorld is the rotation axis in the viewer's frame of reference
+                // This computes the difference between v0 and v1, the 2 mouse positions in the
+                // world space. Note the swap between x and y. mouseMoveWorld is the rotation axis
+                // in the viewer's frame of reference
                 if (this->state.test (visual_state::rotateModMode)) {
                     // Sort of "rotate the page" mode.
                     mouseMoveWorld[2] = -((v1[1] / v1[3]) - (v0[1] / v0[3])) + ((v1[0] / v1[3]) - (v0[0] / v0[3]));


### PR DESCRIPTION
When I changed the framework for storing current scene rotation (storing it now as a mat44 attribute instead of as separate vec translation and quaternion rotation), I didn't quite restore the same 'rotate about the scene origin' behaviour that I wanted to keep. This change fixes that and hopefully paves the way for other ways to rotate the scene (third-person, flight-following view, rotate about screen centre, etc).