### PR TITLE
Use maths from the system if the bundled one is not available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,8 +150,8 @@ if(bundled_maths)
   include_directories(${PROJECT_SOURCE_DIR}/maths)
 else()
   message(STATUS "Using maths from vcpkg")
-  find_path(SEBSJAMES_MATHS_INCLUDE_DIRS "sm/algo" REQUIRED)
-  include_directories(${SEBSJAMES_MATHS_INCLUDE_DIRS})
+  find_path(MATHS_INCLUDE_DIRS "sm/algo" REQUIRED)
+  include_directories(${MATHS_INCLUDE_DIRS})
 endif()
 
 # Use packaged nlohmann json


### PR DESCRIPTION
The changes are quite simple. We first check if the bundled maths is available.
If it is, we will use that (e.g. if we cloned the repository). If it's not (e.g. when building from vcpkg), we will search in the path for a header from sm. I chose algo, but it's just an arbitrary choice - I am open to suggestions.

Also, I saw that you have a `maths-config.cmake`. Can we currently use `find_package` to find maths ? I saw that you included `maths.cmake`, but I couldn't find that file.